### PR TITLE
add cloudtak compatability

### DIFF
--- a/nginx_configs/ots_https
+++ b/nginx_configs/ots_https
@@ -96,6 +96,16 @@ server {
 
         client_max_body_size 100M;
 
+		# CloudTak compatability config
+		location /files {
+		 		proxy_pass http://127.0.0.1:8081;
+		 		proxy_http_version 1.1;
+		 		proxy_set_header Host $host:443;
+		 		proxy_set_header X-Forwarded-For $remote_addr;
+		 		proxy_set_header X-Ssl-Cert $ssl_client_escaped_cert;
+		 		proxy_set_header X-Forwarded-Proto $scheme;
+        }
+
     # listen [::]:8443 ssl ipv6only=on;
     listen 8443 ssl;
     ssl_certificate SERVER_CERT_FILE;


### PR DESCRIPTION
Source: https://docs.opentakserver.io/cloudtak.html
Step 6 in the above documentation is already covered by the installer, this covers step 7. Because might just as well have the config in here.
